### PR TITLE
feat(ci): 新增上游同步工作流与 Pages 部署配置

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,64 @@
+name: Upstream Sync
+
+permissions:
+  contents: write
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  sync_latest_from_upstream:
+    name: Sync latest commits from upstream repo
+    runs-on: ubuntu-latest
+    if: ${{ github.event.repository.fork }}
+
+    steps:
+      - name: Checkout target repo
+        uses: actions/checkout@v6
+
+      - name: Sync upstream changes
+        id: sync
+        uses: aormsby/fork-sync-with-upstream-action@v3.4.3
+        with:
+          upstream_sync_repo: byJoey/cfnew
+          upstream_sync_branch: main
+          target_sync_branch: main
+          target_repo_token: ${{ secrets.GITHUB_TOKEN }}
+          test_mode: false
+
+      - name: Refresh target branch after sync
+        run: |
+          git fetch origin main
+          git checkout main
+          git reset --hard origin/main
+
+      - name: Copy worker source to _worker.js
+        run: |
+          if [ ! -f "少年你相信光吗" ]; then
+            echo "错误：在项目根目录未找到 '少年你相信光吗' 文件。"
+            exit 1
+          fi
+
+          cp "少年你相信光吗" "_worker.js"
+          echo "成功将 '少年你相信光吗' 复制为 '_worker.js'"
+
+      - name: Commit and push _worker.js
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add _worker.js
+
+          if git diff --staged --quiet; then
+            echo "_worker.js is already up-to-date."
+          else
+            git commit -m "Update _worker.js from upstream sync"
+            git push origin HEAD:main
+          fi
+
+      - name: Sync check
+        if: failure()
+        run: |
+          echo "[Error] 自动同步或 _worker.js 生成失败，请检查上游同步状态和 '少年你相信光吗' 文件是否存在。"
+          exit 1

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,8 @@
+name = "v20251104"
+main = "_worker.js"
+compatibility_date = "2025-11-04"
+keep_vars = true
+
+#[[kv_namespaces]]
+#binding = "KV"			#KV绑定名默认不可修改
+#id = ""				#KV数据库id


### PR DESCRIPTION
## 概要
- 新增 GitHub Actions 定时同步任务，用于自动同步上游 main 分支。
- 新增 wrangler.toml，用于 Pages 部署类型，配置 Worker 入口为 _worker.js。

## 改动内容
- 每天定时运行，并支持手动 workflow_dispatch 触发。
- 使用 fork-sync-with-upstream-action 同步 byJoey/cfnew:main。
- 保留参考工作流的 fork 仓库执行条件，并使用 actions/checkout@v6。
- 同步后将 少年你相信光吗 复制为 _worker.js，并在内容变化时自动提交。

## 验证
- 已在本地通过 Ruby YAML 解析检查 workflow 文件。
- PR 分支基于 byJoey/cfnew:main 创建。
- PR 仅包含 Add upstream sync workflow 这一项改动。