### PR TITLE
修复 Star History 图表无法显示的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,4 +413,4 @@ path 示例：
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=byJoey/cfnew&type=Timeline)](https://www.star-history.com/#byJoey/cfnew&Timeline&LogScale)
+[![Star History Chart](https://star-history.dera.page/svg?repos=byJoey/cfnew&type=Timeline)](https://star-history.dera.page/#byJoey/cfnew&Timeline&LogScale)


### PR DESCRIPTION
README 中的 Star History 图表当前已经失效，无法正常显示。原因是 GitHub 星标数据接口受到限制，旧方案不可用。本 MR 将图表切换到新的域名 star-history.dera.page 以恢复图表显示，方便用户查看项目历史星标趋势。