### PR TITLE
ci: 增加每2小时定时触发工作流，为防止过多人使用同一份混淆后的代码而导致被平台识别封禁。

### DIFF
--- a/.github/workflows/obfuscate.yml
+++ b/.github/workflows/obfuscate.yml
@@ -2,6 +2,8 @@ name: Generate and Obfuscate Worker Script
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 */2 * * *'
   push:
     branches:
       - '**'  # 仅匹配分支推送，排除标签推送


### PR DESCRIPTION
在 obfuscate.yml 的 on 下新增 schedule 触发器（cron: '0 */2 * * *'）， 使工作流每 2 小时（UTC 整点）自动运行一次。
防止过多人使用同一份混淆后的代码而导致被平台识别封禁。
